### PR TITLE
Update error message for device initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	startSignalHandler(ctx, wg, cancel)
 	d, err := dev.NewDevice(config.Device)
         if err != nil {
-                log.Fatalf("can't new device : %s", err)
+                log.Fatalf("Cannot init new device : %s", err)
         }
         ble.SetDefaultDevice(d)
 


### PR DESCRIPTION
Hi Jeremy,
  Just a very simple update to the error message in main.go when initialization of the BLE device fails.
  Currently it reads;-   "can't  new device"  , so I've just added the word "init" to make it a little bit more user friendly.
 
  Very many thanks for your work creating and maintaining the package,

                  -John-


----
Very minor change to add the information about -what- the failure is. Added initial capitalization to match other messages. Dropped the apostrophed "can't" to make life a little simpler for downstream parsers.